### PR TITLE
IONPORTAL-561 Убрал использование модуля gulp-jsmin т.к. он вызывает

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ const gulpDest = require('gulp').dest;
 const assert = require('assert');
 
 const cssMin = require('gulp-clean-css');
-const jsMin = require('gulp-jsmin');
+const jsMin = require('gulp-minify');
 const rename = require('gulp-rename');
 const spawn = require('child_process').spawn;
 const extend = require('extend');

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "gulp": "^4.0.2",
     "gulp-clean-css": "~4.0.0",
-    "gulp-jsmin": "~0.1.5",
+    "gulp-minify": "~3.1.0",
     "gulp-rename": "~1.4.0"
   }
 }


### PR DESCRIPTION
устаревший вредный модуль graceful-fs изза которого не работает deploy
при фийловом репозитории настроек